### PR TITLE
Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,26 @@
+CC = gcc
+CFLAGS = -Wall -Wextra -Werror -std=c11
+LDFLAGS = -lm
+
+.PHONY: all clean verify_format format test
+
+all: test
+
+clean:
+	rm -f *.o *.a *_test
+
+verify_format:
+	find . -type f -regex ".*\.[ch]" -exec clang-format --style=LLVM --dry-run -Werror {} +
+
+format:
+	find . -type f -regex ".*\.[ch]" -exec clang-format --style=LLVM -i {} +
+
+test:
+	@for test_file in $$(find . -maxdepth 1 -name "*_test.c"); do \
+		base=$$(basename "$$test_file" .c); \
+		main_file=$${base%%_test*}.c; \
+		echo "Building $$base from $$main_file and $$test_file"; \
+		$(CC) $(CFLAGS) $$main_file $$test_file -o $$base $(LDFLAGS); \
+		echo "Running $$base..."; \
+		./$$base || exit 1; \
+	done


### PR DESCRIPTION
Подготовить общий Makefile
Предусмотреть цели для:
очистка рабочей директории от генерируемых файлов
проверка форматирования
форматирование
запуск тестов (любые файлы с суффиксом _test)

Исполнитель : Шкурин Михаил